### PR TITLE
Emit initial syncing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.30.0
+
+- Emit errors that happened during initial bulk sync
+
 # 0.29.0
 
 - Optionally pass `mapper` for an override.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2elastic",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "description": "Sync MongoDB collections to Elasticsearch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/syncData.ts
+++ b/src/syncData.ts
@@ -106,6 +106,7 @@ export const initSync = (
         emit('process', {
           success: docs.length - numErrors,
           fail: numErrors,
+          errors,
           initialScan: true,
         })
       } else {


### PR DESCRIPTION
This piece of information is essential when debugging initial syncing errors