### PR TITLE
Removed options.mapper in favor of options.rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.39.0
 
 - Removed `options.mapper` in favor of `options.rename` which takes an object of dotted path to renamed dotted path.
-  The `rename` option is available for syncing and converting a schema to a table.
+  The `rename` option is available for syncing and converting a schema to a table.`_id` mapped to `_mongoId` by default.
 
 # 0.38.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.39.0
+
+- Removed `options.mapper` in favor of `options.rename` which takes an object of dotted path to renamed dotted path.
+  The `rename` option is available for syncing and converting a schema to a table.
+
 # 0.38.0
 
 - Added `operationCounts` to the `process` event.
@@ -9,7 +14,7 @@
 # 0.36.0
 
 - `processChangeStream` now batches records. Default timeout before the queue is automatically
-flushed is 30 seconds.
+  flushed is 30 seconds.
 
 # 0.35.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "mongo2elastic",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2elastic",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
+        "dupes-of-hazard": "^0.1.0",
         "eventemitter3": "^5.0.1",
         "lodash": "^4.17.21",
+        "make-error": "^1.3.6",
         "minimatch": "^6.2.0",
         "mongochangestream": "^0.43.0",
         "obj-walker": "^1.7.0",
@@ -2440,6 +2442,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dupes-of-hazard": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
+      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
+      "dependencies": {
+        "json-stable-stringify": "^1.0.2",
+        "make-error": "^1.3.6"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.228",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
@@ -4001,6 +4012,17 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dependencies": {
+        "jsonify": "^0.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4017,6 +4039,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/kleur": {
@@ -7326,6 +7356,15 @@
         "esutils": "^2.0.2"
       }
     },
+    "dupes-of-hazard": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
+      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
+      "requires": {
+        "json-stable-stringify": "^1.0.2",
+        "make-error": "^1.3.6"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.228",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
@@ -8500,6 +8539,14 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "json-stable-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "requires": {
+        "jsonify": "^0.0.1"
+      }
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8511,6 +8558,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
-        "dupes-of-hazard": "^0.1.0",
         "eventemitter3": "^5.0.1",
         "lodash": "^4.17.21",
         "make-error": "^1.3.6",
@@ -2442,15 +2441,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/dupes-of-hazard": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
-      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
-      "dependencies": {
-        "json-stable-stringify": "^1.0.2",
-        "make-error": "^1.3.6"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.228",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
@@ -4012,17 +4002,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
-      "dependencies": {
-        "jsonify": "^0.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -4039,14 +4018,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/kleur": {
@@ -7356,15 +7327,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dupes-of-hazard": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dupes-of-hazard/-/dupes-of-hazard-0.1.0.tgz",
-      "integrity": "sha512-c3M/IAoVi0J29/Aml2DsQGJbtiuUPiPByFyc8e200c+438K3TBam9zLD4pK7I9UpsYnABuYX66BwoeRsd6inlg==",
-      "requires": {
-        "json-stable-stringify": "^1.0.2",
-        "make-error": "^1.3.6"
-      }
-    },
     "electron-to-chromium": {
       "version": "1.4.228",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.228.tgz",
@@ -8539,14 +8501,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-      "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
-      "requires": {
-        "jsonify": "^0.0.1"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -8558,11 +8512,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
-    },
-    "jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2elastic",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Sync MongoDB collections to Elasticsearch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -51,8 +51,10 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
+    "dupes-of-hazard": "^0.1.0",
     "eventemitter3": "^5.0.1",
     "lodash": "^4.17.21",
+    "make-error": "^1.3.6",
     "minimatch": "^6.2.0",
     "mongochangestream": "^0.43.0",
     "obj-walker": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "eslint": "^8.39.0",
     "jest": "^28.1.3",
-    "ts-jest": "^28.0.8",
     "prettier": "^2.8.8",
+    "ts-jest": "^28.0.8",
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
@@ -51,7 +51,6 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
-    "dupes-of-hazard": "^0.1.0",
     "eventemitter3": "^5.0.1",
     "lodash": "^4.17.21",
     "make-error": "^1.3.6",

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -488,7 +488,7 @@ describe('convertSchema', () => {
       passthrough: ['copy_to'],
       rename: {
         numberOfEmployees: 'numEmployees',
-        'addresses.address': 'addresses.address1',
+        'addresses.address.address1': 'addresses.address.street',
       },
     }
     const result = convertSchema(schema, options)
@@ -509,9 +509,9 @@ describe('convertSchema', () => {
         numEmployees: { type: 'keyword', copy_to: 'all' },
         addresses: {
           properties: {
-            address1: {
+            address: {
               properties: {
-                address1: {
+                street: {
                   type: 'text',
                   fields: { keyword: { type: 'keyword', ignore_above: 256 } },
                   copy_to: 'all',

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -119,6 +119,7 @@ describe('convertSchema', () => {
   test('Convert MongoDB schema to Elastic', () => {
     expect(convertSchema(schema)).toEqual({
       properties: {
+        _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
         name: {
           type: 'text',
@@ -204,6 +205,7 @@ describe('convertSchema', () => {
     }
     expect(convertSchema(schema, options)).toEqual({
       properties: {
+        _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
         name: {
           type: 'text',
@@ -302,6 +304,7 @@ describe('convertSchema', () => {
     const result = convertSchema(schema, options)
     expect(result).toEqual({
       properties: {
+        _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
         name: {
           type: 'text',
@@ -394,6 +397,7 @@ describe('convertSchema', () => {
     const result = convertSchema(schema, options)
     expect(result).toEqual({
       properties: {
+        _mongoId: { type: 'keyword', copy_to: 'all' },
         parentId: { type: 'keyword', copy_to: 'all' },
         name: {
           type: 'text',
@@ -476,5 +480,120 @@ describe('convertSchema', () => {
         createdAt: { type: 'date', copy_to: 'all' },
       },
     })
+  })
+  test('Should rename fields in the schema', () => {
+    const options = {
+      omit: ['integrations', 'permissions'],
+      overrides: [{ path: '*', copy_to: 'all' }],
+      passthrough: ['copy_to'],
+      rename: {
+        numberOfEmployees: 'numEmployees',
+        'addresses.address': 'addresses.address1',
+      },
+    }
+    const result = convertSchema(schema, options)
+    expect(result).toEqual({
+      properties: {
+        _mongoId: { type: 'keyword', copy_to: 'all' },
+        parentId: { type: 'keyword', copy_to: 'all' },
+        name: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
+        subType: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
+        numEmployees: { type: 'keyword', copy_to: 'all' },
+        addresses: {
+          properties: {
+            address1: {
+              properties: {
+                address1: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                address2: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                city: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                county: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                state: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                zip: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                country: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+                latitude: { type: 'long', copy_to: 'all' },
+                longitude: { type: 'long', copy_to: 'all' },
+                timezone: {
+                  type: 'text',
+                  fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+                  copy_to: 'all',
+                },
+              },
+            },
+            name: {
+              type: 'text',
+              fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+              copy_to: 'all',
+            },
+            isPrimary: { type: 'boolean', copy_to: 'all' },
+          },
+        },
+        logo: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
+        verified: { type: 'boolean', copy_to: 'all' },
+        partner: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
+        createdAt: { type: 'date', copy_to: 'all' },
+      },
+    })
+  })
+  test('Should throw an exception if a rename field path prefix is different', () => {
+    expect(() =>
+      convertSchema(schema, {
+        rename: {
+          'integrations.stripe': 'foo.bar',
+        },
+      })
+    ).toThrow('Rename path prefix does not match: integrations.stripe')
+  })
+  test('Should throw an exception if a rename results in duplicate paths', () => {
+    expect(() =>
+      convertSchema(schema, {
+        rename: {
+          parentId: 'name',
+        },
+      })
+    ).toThrow('Renaming parentId to name will overwrite property "name"')
   })
 })

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -92,6 +92,7 @@ export const convertSchema = (
     for (const dottedPath in rename) {
       const oldPath = dottedPath.split('.')
       const newPath = rename[dottedPath].split('.')
+      // Only allow renames such that nodes still keep the same parent
       if (!arrayStartsWith(oldPath, newPath.slice(0, -1))) {
         throw new Mongo2ElasticError(
           `Rename path prefix does not match: ${dottedPath}`
@@ -99,7 +100,7 @@ export const convertSchema = (
       }
     }
 
-    // Walk every node in the schema and rename children
+    // Walk every subschema, renaming properties
     walker(
       schema,
       ({ val: { bsonType, properties }, path }) => {

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -70,8 +70,6 @@ export const convertSchema = (
   const omit = options.omit ? options.omit.map(_.toPath) : []
   const overrides = options.overrides || []
 
-  type Schema = Record<string, estypes.MappingProperty>
-
   const omitNodes = (node: Node) => {
     const { val, path } = node
     if (val?.bsonType) {
@@ -88,7 +86,7 @@ export const convertSchema = (
     return val
   }
 
-  const handleRename = (schema: Schema, rename: Record<string, string>) => {
+  const handleRename = (schema: JSONSchema, rename: Record<string, string>) => {
     for (const dottedPath in rename) {
       const oldPath = dottedPath.split('.')
       const newPath = rename[dottedPath].split('.')
@@ -162,7 +160,7 @@ export const convertSchema = (
   }
 
   // Recursively convert the schema
-  const schema = map(jsonSchema, omitNodes) as Schema
+  const schema = map(jsonSchema, omitNodes) as JSONSchema
   handleRename(schema, { _id: '_mongoId', ...options.rename })
-  return map(schema, overrideNodes) as Schema
+  return map(schema, overrideNodes) as estypes.MappingPropertyBase
 }

--- a/src/syncData.ts
+++ b/src/syncData.ts
@@ -3,6 +3,7 @@ import type {
   ChangeStreamDocument,
   ChangeStreamInsertDocument,
   Collection,
+  Document,
 } from 'mongodb'
 import type { Redis } from 'ioredis'
 import elasticsearch from '@elastic/elasticsearch'
@@ -12,7 +13,7 @@ import mongoChangeStream, {
 } from 'mongochangestream'
 import { QueueOptions } from 'prom-utils'
 import { SyncOptions, Events, ConvertOptions } from './types.js'
-import { indexFromCollection } from './util.js'
+import { renameKeys, indexFromCollection } from './util.js'
 import { convertSchema } from './convertSchema.js'
 import { BulkResponse } from '@elastic/elasticsearch/lib/api/typesWithBodyKey.js'
 
@@ -43,7 +44,8 @@ export const initSync = (
   elastic: elasticsearch.Client,
   options: SyncOptions & mongoChangeStream.SyncOptions = {}
 ) => {
-  const mapper = options.mapper || _.omit(['_id'])
+  const mapper = (doc: Document) =>
+    renameKeys(doc, { _id: '_mongoId', ...options.rename })
   const index = options.index || indexFromCollection(collection)
   // Initialize sync
   const sync = mongoChangeStream.initSync<Events>(redis, collection, options)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
 import type { Document } from 'mongodb'
 import { JSONSchema } from 'mongochangestream'
 
-export interface SyncOptions {
+interface RenameOption {
+  /** Dotted path to renamed dotted path */
+  rename?: Record<string, string>
+}
+
+export interface SyncOptions extends RenameOption {
   mapper?: (doc: Document) => Document
   index?: string
 }
@@ -11,7 +16,7 @@ export interface Override extends Record<string, any> {
   mapper?: (obj: JSONSchema, path: string) => JSONSchema
 }
 
-export interface ConvertOptions {
+export interface ConvertOptions extends RenameOption {
   omit?: string[]
   overrides?: Override[]
   passthrough?: string[]

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,34 @@
-import { Collection } from 'mongodb'
+import _ from 'lodash/fp.js'
+import { Document, Collection } from 'mongodb'
 
 export const indexFromCollection = (collection: Collection) =>
   collection.collectionName.toLowerCase()
 
 export const indexFromDbAndCollection = (collection: Collection) =>
   `${collection.dbName.toLowerCase()}_${collection.collectionName.toLowerCase()}`
+
+/**
+ * Does arr start with startsWith array.
+ */
+export const arrayStartsWith = (arr: any[], startsWith: any[]) => {
+  for (let i = 0; i < startsWith.length; i++) {
+    if (arr[i] !== startsWith[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+export const renameKey = (doc: Document, key: string, newKey: string) =>
+  _.flow(_.set(newKey, _.get(key, doc)), _.omit([key]))(doc)
+
+export const renameKeys = (doc: Document, keys: Record<string, string>) => {
+  let newDoc = doc
+  for (const key in keys) {
+    if (_.has(key, doc)) {
+      const newKey = keys[key]
+      newDoc = renameKey(newDoc, key, newKey)
+    }
+  }
+  return newDoc
+}


### PR DESCRIPTION
The new option `rename` is an object of keys to be renamed. It gets applied when converting mongo schemas to elastic schemas and also when syncing documents.

Mostly a copy of https://github.com/smartprocure/mongo2crate/pull/5