### PR TITLE
Fix `passthrough` when set for an array field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.39.1
+
+- Fix `passthrough` when set for an array field.
+
 # 0.39.0
 
 - Removed `options.mapper` in favor of `options.rename` which takes an object of dotted path to renamed dotted path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.39.1
 
 - Fix `passthrough` when set for an array field.
+- Better passthrough logic for text fields.
 
 # 0.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.39.1
 
 - Fix `passthrough` when set for an array field.
-- Better passthrough logic for text fields.
+- Better `passthrough` logic for `text` fields.
 
 # 0.39.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2elastic",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2elastic",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2elastic",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Sync MongoDB collections to Elasticsearch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -15,6 +15,7 @@ describe('convertSchema', () => {
       },
       name: {
         bsonType: 'string',
+        copy_to: 'searchbar',
       },
       subType: {
         bsonType: 'string',
@@ -22,6 +23,14 @@ describe('convertSchema', () => {
       numberOfEmployees: {
         bsonType: 'string',
         enum: ['1 - 5', '6 - 20', '21 - 50', '51 - 200', '201 - 500', '500+'],
+      },
+      keywords: {
+        bsonType: 'array',
+        items: {
+          bsonType: 'string',
+        },
+        copy_to: 'searchbar',
+        description: 'Some description',
       },
       addresses: {
         bsonType: 'array',
@@ -116,10 +125,10 @@ describe('convertSchema', () => {
       },
     },
   }
-  test('Convert MongoDB schema to Elastic', () => {
-    expect(convertSchema(schema)).toEqual({
+  test('Convert MongoDB schema to Elastic with no options', () => {
+    const mappings = convertSchema(schema)
+    expect(mappings).toEqual({
       properties: {
-        _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
         name: {
           type: 'text',
@@ -129,8 +138,10 @@ describe('convertSchema', () => {
           type: 'text',
           fields: { keyword: { type: 'keyword', ignore_above: 256 } },
         },
-        numberOfEmployees: {
-          type: 'keyword',
+        numberOfEmployees: { type: 'keyword' },
+        keywords: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
         },
         addresses: {
           properties: {
@@ -194,29 +205,37 @@ describe('convertSchema', () => {
           type: 'text',
           fields: { keyword: { type: 'keyword', ignore_above: 256 } },
         },
+        _mongoId: { type: 'keyword' },
       },
     })
   })
   test('Convert MongoDB schema to Elastic with options', () => {
     const options = {
-      omit: ['integrations', 'permissions'],
-      overrides: [{ path: 'addresses.address.l*', bsonType: 'double' }],
+      omit: ['integrations'],
+      overrides: [
+        { path: 'addresses.address.l*', bsonType: 'double' },
+        { path: 'permissions', copy_to: 'searchbar' },
+      ],
       passthrough: ['copy_to'],
     }
-    expect(convertSchema(schema, options)).toEqual({
+    const mappings = convertSchema(schema, options)
+    expect(mappings).toEqual({
       properties: {
-        _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
         name: {
           type: 'text',
           fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'searchbar',
         },
         subType: {
           type: 'text',
           fields: { keyword: { type: 'keyword', ignore_above: 256 } },
         },
-        numberOfEmployees: {
-          type: 'keyword',
+        numberOfEmployees: { type: 'keyword' },
+        keywords: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'searchbar',
         },
         addresses: {
           properties: {
@@ -282,6 +301,12 @@ describe('convertSchema', () => {
           fields: { keyword: { type: 'keyword', ignore_above: 256 } },
         },
         createdAt: { type: 'date' },
+        permissions: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'searchbar',
+        },
+        _mongoId: { type: 'keyword' },
       },
     })
   })
@@ -301,8 +326,8 @@ describe('convertSchema', () => {
       ],
       passthrough: ['copy_to'],
     }
-    const result = convertSchema(schema, options)
-    expect(result).toEqual({
+    const mappings = convertSchema(schema, options)
+    expect(mappings).toEqual({
       properties: {
         _mongoId: { type: 'keyword' },
         parentId: { type: 'keyword' },
@@ -317,6 +342,11 @@ describe('convertSchema', () => {
           copy_to: 'foo',
         },
         numberOfEmployees: { type: 'keyword', copy_to: 'foo' },
+        keywords: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'searchbar',
+        },
         addresses: {
           properties: {
             address: {
@@ -394,8 +424,8 @@ describe('convertSchema', () => {
       overrides: [{ path: '*', copy_to: 'all' }],
       passthrough: ['copy_to'],
     }
-    const result = convertSchema(schema, options)
-    expect(result).toEqual({
+    const mappings = convertSchema(schema, options)
+    expect(mappings).toEqual({
       properties: {
         _mongoId: { type: 'keyword', copy_to: 'all' },
         parentId: { type: 'keyword', copy_to: 'all' },
@@ -410,6 +440,11 @@ describe('convertSchema', () => {
           copy_to: 'all',
         },
         numberOfEmployees: { type: 'keyword', copy_to: 'all' },
+        keywords: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
         addresses: {
           properties: {
             address: {
@@ -491,8 +526,8 @@ describe('convertSchema', () => {
         'addresses.address.address1': 'addresses.address.street',
       },
     }
-    const result = convertSchema(schema, options)
-    expect(result).toEqual({
+    const mappings = convertSchema(schema, options)
+    expect(mappings).toEqual({
       properties: {
         _mongoId: { type: 'keyword', copy_to: 'all' },
         parentId: { type: 'keyword', copy_to: 'all' },
@@ -507,6 +542,11 @@ describe('convertSchema', () => {
           copy_to: 'all',
         },
         numEmployees: { type: 'keyword', copy_to: 'all' },
+        keywords: {
+          type: 'text',
+          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          copy_to: 'all',
+        },
         addresses: {
           properties: {
             address: {

--- a/src/convertSchema.test.ts
+++ b/src/convertSchema.test.ts
@@ -214,9 +214,13 @@ describe('convertSchema', () => {
       omit: ['integrations'],
       overrides: [
         { path: 'addresses.address.l*', bsonType: 'double' },
-        { path: 'permissions', copy_to: 'searchbar' },
+        {
+          path: 'permissions',
+          copy_to: 'searchbar',
+          fields: { exact: { analyzer: 'exact', type: 'text' } },
+        },
       ],
-      passthrough: ['copy_to'],
+      passthrough: ['copy_to', 'fields'],
     }
     const mappings = convertSchema(schema, options)
     expect(mappings).toEqual({
@@ -303,7 +307,10 @@ describe('convertSchema', () => {
         createdAt: { type: 'date' },
         permissions: {
           type: 'text',
-          fields: { keyword: { type: 'keyword', ignore_above: 256 } },
+          fields: {
+            keyword: { type: 'keyword', ignore_above: 256 },
+            exact: { analyzer: 'exact', type: 'text' },
+          },
           copy_to: 'searchbar',
         },
         _mongoId: { type: 'keyword' },

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -38,16 +38,18 @@ const convertSchemaNode = (obj: JSONSchema, passthrough: object) => {
   const elasticType = bsonTypeToElastic[obj.bsonType]
   // Add keyword sub-field to text type automatically
   if (elasticType === 'text') {
-    return _.merge({
-      type: 'text',
-      fields: {
-        keyword: {
-          type: 'keyword',
-          ignore_above: 256,
+    return _.merge(
+      {
+        type: 'text',
+        fields: {
+          keyword: {
+            type: 'keyword',
+            ignore_above: 256,
+          },
         },
       },
-      passthrough,
-    })
+      passthrough
+    )
   }
   if (elasticType) {
     return { type: elasticType, ...passthrough }

--- a/src/convertSchema.ts
+++ b/src/convertSchema.ts
@@ -38,7 +38,7 @@ const convertSchemaNode = (obj: JSONSchema, passthrough: object) => {
   const elasticType = bsonTypeToElastic[obj.bsonType]
   // Add keyword sub-field to text type automatically
   if (elasticType === 'text') {
-    return {
+    return _.merge({
       type: 'text',
       fields: {
         keyword: {
@@ -46,8 +46,8 @@ const convertSchemaNode = (obj: JSONSchema, passthrough: object) => {
           ignore_above: 256,
         },
       },
-      ...passthrough,
-    }
+      passthrough,
+    })
   }
   if (elasticType) {
     return { type: elasticType, ...passthrough }


### PR DESCRIPTION
* Fixes the underlying issue which is that `passthrough` fields are being ignored for array fields.
* Better passthrough logic for text fields.

If merged, this would supersede https://github.com/smartprocure/mongo2elastic/pull/10