### PR TITLE
Fix BSONObjectTooLarge issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.40.0
+
+- Remove `updateDescription` since it is not needed and may cause a `BSONObjectTooLarge` error.
+
 # 0.39.1
 
 - Fix `passthrough` when set for an array field.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2elastic",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2elastic",
-      "version": "0.39.1",
+      "version": "0.40.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2elastic",
-  "version": "0.39.1",
+  "version": "0.40.0",
   "description": "Sync MongoDB collections to Elasticsearch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/syncData.ts
+++ b/src/syncData.ts
@@ -172,8 +172,14 @@ export const initSync = (
     }
   }
 
-  const processChangeStream = (options?: QueueOptions & ChangeStreamOptions) =>
-    sync.processChangeStream(processChangeStreamRecords, options)
+  const processChangeStream = (options: QueueOptions & ChangeStreamOptions) =>
+    sync.processChangeStream(processChangeStreamRecords, {
+      ...options,
+      pipeline: [
+        { $unset: ['updateDescription'] },
+        ...(options?.pipeline ?? []),
+      ],
+    })
   const runInitialScan = (options?: QueueOptions & ScanOptions) =>
     sync.runInitialScan(processRecords, options)
 


### PR DESCRIPTION
Exclude `updateDescription` from pipeline to allow for larger documents to pass through.