### PR TITLE
Fix the `repository` property type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
-  "repository": "git://github.com/smartprocure/mongo2elastic.git",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/smartprocure/mongo2elastic.git"
+  },
   "scripts": {
     "prepare": "npm test && npm run lint && npm run build",
     "test": "vitest run",


### PR DESCRIPTION
When I ran `npm publish`, I noticed this in the output:

> npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors. npm warn publish errors corrected:
> npm warn publish "repository" was changed from a string to an object


Running `npm pkg fix` produced this change in package.json.