### PR TITLE
0.51.0: Bump mongochangestream to pick up refresh token improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.51.0
+
+- Latest `mongochangestream` - Performance improvements related to updating the
+  refresh token more often. See [mongochangestream
+  changelog](https://github.com/smartprocure/mongochangestream/blob/master/CHANGELOG.md#0590)
+
 # 0.50.0
 
 - Remove try/catch and rely on retry logic in `mongochangestream`.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,16 @@ const options = { batchSize: 1000 }
 const initialScan = await sync.runInitialScan(options)
 initialScan.start()
 ```
+
+## Run the tests locally
+
+Create a .env file with the following variables set to the appropriate values:
+
+```
+MONGO_CONN="mongodb+srv://..."
+ELASTIC_NODE='https://elastic-node-url-here.com'
+ELASTIC_USERNAME="username-here"
+ELASTIC_PASSWORD="password-here"
+```
+
+Then run `npm test` to run the tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongo2elastic",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongo2elastic",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
@@ -14,7 +14,7 @@
         "lodash": "^4.17.21",
         "make-error": "^1.3.6",
         "minimatch": "^10.0.1",
-        "mongochangestream": "^0.58.0",
+        "mongochangestream": "^0.59.0",
         "obj-walker": "^2.4.0",
         "prom-utils": "^0.14.0"
       },
@@ -2752,9 +2752,10 @@
       }
     },
     "node_modules/mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
+      "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",
@@ -5475,9 +5476,9 @@
       }
     },
     "mongochangestream": {
-      "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.58.0.tgz",
-      "integrity": "sha512-UUs3JsyKORSJjqwg6ADV8GBYSptIHPO1I+E0RhFjjKk3B/14lgLb5OcKZrYo3DYg+ObysVZw2bkPPGzkdsuNcw==",
+      "version": "0.59.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream/-/mongochangestream-0.59.0.tgz",
+      "integrity": "sha512-MJBvX5YUXvv3/Hrl+fYlQ3AXFJaKJnUIyP3w3vkPyNAbvFSEZdmalaGKDlR2KHmM0osh5vTKUu/sq+QnFYlL0A==",
       "requires": {
         "debug": "^4.4.0",
         "eventemitter3": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "globals": "^15.14.0",
-        "mongochangestream-testing": "^0.1.0",
+        "mongochangestream-testing": "^0.5.0",
         "ms": "^2.1.3",
         "prettier": "^3.4.2",
         "typescript": "^5.7.2",
@@ -2775,13 +2775,15 @@
       }
     },
     "node_modules/mongochangestream-testing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.1.0.tgz",
-      "integrity": "sha512-1H6dndz5y3ipP8vajJ3l3zEfEzb2r6+lh0qZhLHzq05a5m5YI5O9i+w6PFJy3uQ3yKLciAgpowR0Gb+YuHXzlw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "node_modules/mongodb": {
@@ -5491,13 +5493,14 @@
       }
     },
     "mongochangestream-testing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.1.0.tgz",
-      "integrity": "sha512-1H6dndz5y3ipP8vajJ3l3zEfEzb2r6+lh0qZhLHzq05a5m5YI5O9i+w6PFJy3uQ3yKLciAgpowR0Gb+YuHXzlw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
       "requires": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "mongodb": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo2elastic",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Sync MongoDB collections to Elasticsearch",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -64,7 +64,7 @@
     "lodash": "^4.17.21",
     "make-error": "^1.3.6",
     "minimatch": "^10.0.1",
-    "mongochangestream": "^0.58.0",
+    "mongochangestream": "^0.59.0",
     "obj-walker": "^2.4.0",
     "prom-utils": "^0.14.0"
   },
@@ -72,8 +72,12 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "es5",
-    "plugins": ["@trivago/prettier-plugin-sort-imports"],
-    "importOrder": ["^[./]"],
+    "plugins": [
+      "@trivago/prettier-plugin-sort-imports"
+    ],
+    "importOrder": [
+      "^[./]"
+    ],
     "importOrderSortSpecifiers": true,
     "importOrderCaseInsensitive": true,
     "importOrderSeparation": true

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "globals": "^15.14.0",
-    "mongochangestream-testing": "^0.1.0",
+    "mongochangestream-testing": "^0.5.0",
     "ms": "^2.1.3",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",

--- a/src/syncData.test.ts
+++ b/src/syncData.test.ts
@@ -3,50 +3,16 @@ import debug from 'debug'
 import Redis from 'ioredis'
 import _ from 'lodash/fp.js'
 import {
+  assertEventually,
   initState as initRedisAndMongoState,
   numDocs,
 } from 'mongochangestream-testing'
 import { type Db, MongoClient } from 'mongodb'
 import ms from 'ms'
 import { setTimeout } from 'node:timers/promises'
-import { TimeoutError, WaitOptions, waitUntil } from 'prom-utils'
-import { assert, describe, test } from 'vitest'
+import { describe, test } from 'vitest'
 
 import { initSync, SyncOptions } from './index.js'
-
-// FIXME: Pull in `assertEventually` from mongochangestream-testing instead.
-
-/**
- * Asserts that the provided predicate eventually returns true.
- *
- * @param pred - The predicate to check: an async function returning a boolean.
- * @param failureMessage - The message to display if the predicate does not
- * return true before the timeout.
- * @param [waitOptions] - Options to override the default options passed into
- * `waitUntil`.
- *
- * @throws AssertionError if the predicate does not return true before the
- * timeout.
- */
-export const assertEventually = async (
-  pred: () => Promise<boolean>,
-  failureMessage = 'Failed to satisfy predicate',
-  waitOptions: WaitOptions = {}
-) => {
-  try {
-    await waitUntil(pred, {
-      timeout: ms('60s'),
-      checkFrequency: ms('50ms'),
-      ...waitOptions,
-    })
-  } catch (e) {
-    if (e instanceof TimeoutError) {
-      assert.fail(failureMessage)
-    } else {
-      throw e
-    }
-  }
-}
 
 // Output via console.info (stdout) instead of stderr.
 // Without this debug statements are swallowed by vitest.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig(({ mode }) => ({
   test: {
     env: loadEnv(mode, process.cwd(), ''),
-    testTimeout: 30000,
+    testTimeout: 60000,
   },
 }))


### PR DESCRIPTION
This bumps the mongochangestream dependency to pick up the refresh token related improvements (https://github.com/smartprocure/mongochangestream/pull/37).

Tests are all passing with `assertEventually` in place. I currently have it inlined. Once https://github.com/smartprocure/mongochangestream-testing/pull/2 is merged and published, I will update this PR to use `assertEventually` from that library instead, and take the PR out of Draft.